### PR TITLE
#4 - switched from helidon webserver to vertx

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -102,11 +102,12 @@ lazy val oni = project
         postgresql,
         slf4jSystem,
         tapirCirce,
-        tapirHelidon,
+//        tapirHelidon,
         tapirPrometheus,
         tapirServerStub   % Test,
         tapirSttpCirce,
         tapirSwagger,
+        tapirVertex,
         typesafeConfig
     )
   )

--- a/it/src/main/scala/org/mbari/oni/endpoints/AuthorizationEndpointsSuite.scala
+++ b/it/src/main/scala/org/mbari/oni/endpoints/AuthorizationEndpointsSuite.scala
@@ -23,10 +23,11 @@ import org.mbari.oni.etc.jwt.JwtService
 import org.mbari.oni.jpa.DatabaseFunSuite
 import org.mbari.oni.services.UserAccountService
 import sttp.client3.*
-
 import sttp.model.StatusCode
+import org.mbari.oni.etc.sdk.Futures.*
 
 import java.util.Base64
+import scala.concurrent.ExecutionContext
 
 trait AuthorizationEndpointsSuite extends DatabaseFunSuite with EndpointsSuite:
 
@@ -41,6 +42,8 @@ trait AuthorizationEndpointsSuite extends DatabaseFunSuite with EndpointsSuite:
             .post(uri"http://test.com/v1/auth")
             .header("Authorization", "APIKEY foo")
             .send(backendStub)
+            .join
+
 
         response.body match
             case Left(e)     => fail(e)
@@ -72,6 +75,7 @@ trait AuthorizationEndpointsSuite extends DatabaseFunSuite with EndpointsSuite:
                     .post(uri"http://test.com/v1/auth/login")
                     .header("Authorization", s"BASIC $credentials")
                     .send(backendStub)
+                    .join
 
                 response.body match
                     case Left(e)     =>

--- a/it/src/main/scala/org/mbari/oni/endpoints/ConceptEndpointsSuite.scala
+++ b/it/src/main/scala/org/mbari/oni/endpoints/ConceptEndpointsSuite.scala
@@ -25,6 +25,8 @@ import org.mbari.oni.etc.jwt.JwtService
 import org.mbari.oni.services.UserAuthMixin
 import sttp.model.StatusCode
 
+import scala.concurrent.ExecutionContext
+
 trait ConceptEndpointsSuite extends EndpointsSuite with DataInitializer with UserAuthMixin:
 
     given jwtService: JwtService         = JwtService("mbari", "foo", "bar")

--- a/it/src/main/scala/org/mbari/oni/endpoints/ConceptNameEndpointsSuite.scala
+++ b/it/src/main/scala/org/mbari/oni/endpoints/ConceptNameEndpointsSuite.scala
@@ -23,6 +23,8 @@ import org.mbari.oni.services.UserAuthMixin
 import sttp.model.StatusCode
 import org.mbari.oni.etc.circe.CirceCodecs.{*, given}
 
+import scala.concurrent.ExecutionContext
+
 trait ConceptNameEndpointsSuite extends EndpointsSuite with DataInitializer with UserAuthMixin:
 
     given jwtService: JwtService             = JwtService("mbari", "foo", "bar")

--- a/oni/src/main/scala/org/mbari/oni/AppConfig.scala
+++ b/oni/src/main/scala/org/mbari/oni/AppConfig.scala
@@ -25,6 +25,8 @@ object AppConfig:
 
     val Description: String = "Organism Naming Infrastructure: Knowledge-base and User Accounts"
 
+    val NumberOfVertxWorkers: Int = 20
+
     lazy val DefaultJwtConfig: JwtConfig = JwtConfig(
         issuer = Config.getString("basicjwt.issuer"),
         apiKey = Config.getString("basicjwt.client.secret"),

--- a/oni/src/main/scala/org/mbari/oni/endpoints/HealthEndpoints.scala
+++ b/oni/src/main/scala/org/mbari/oni/endpoints/HealthEndpoints.scala
@@ -19,7 +19,7 @@ import org.mbari.oni.etc.circe.CirceCodecs.given
 import org.mbari.oni.domain.{ErrorMsg, HealthStatus}
 import sttp.shared.Identity
 
-class HealthEndpoints extends Endpoints:
+class HealthEndpoints(using executionContext: ExecutionContext) extends Endpoints:
 
     val healthEndpoint: Endpoint[Unit, Unit, ErrorMsg, HealthStatus, Any] =
         openEndpoint
@@ -30,10 +30,10 @@ class HealthEndpoints extends Endpoints:
             .description("Health check")
             .tag("Health")
 
-    val healthEndpointImpl: ServerEndpoint[Any, Identity] =
-        healthEndpoint.serverLogic(_ => Right(HealthStatus.Default))
+    val healthEndpointImpl: ServerEndpoint[Any, Future] =
+        healthEndpoint.serverLogic(_ => Future(Right(HealthStatus.Default)))
 
     override def all: List[Endpoint[?, ?, ?, ?, ?]] =
         List(healthEndpoint)
 
-    override def allImpl: List[ServerEndpoint[Any, Identity]] = List(healthEndpointImpl)
+    override def allImpl: List[ServerEndpoint[Any, Future]] = List(healthEndpointImpl)

--- a/oni/src/main/scala/org/mbari/oni/endpoints/LinkEndpoints.scala
+++ b/oni/src/main/scala/org/mbari/oni/endpoints/LinkEndpoints.scala
@@ -17,7 +17,9 @@ import sttp.tapir.Endpoint
 import sttp.tapir.json.circe.*
 import sttp.tapir.server.ServerEndpoint
 
-class LinkEndpoints(entityManagerFactory: EntityManagerFactory) extends Endpoints:
+import scala.concurrent.{ExecutionContext, Future}
+
+class LinkEndpoints(entityManagerFactory: EntityManagerFactory)(using executionContext: ExecutionContext) extends Endpoints:
 
     private val service = LinkService(entityManagerFactory)
     private val base    = "links"
@@ -32,8 +34,8 @@ class LinkEndpoints(entityManagerFactory: EntityManagerFactory) extends Endpoint
         .description("Get all link templates")
         .tag(tag)
 
-    val allLinksEndpointImpl: ServerEndpoint[Any, Identity] = allLinksEndpoint.serverLogic { _ =>
-        handleErrors(service.findAllLinkTemplates())
+    val allLinksEndpointImpl: ServerEndpoint[Any, Future] = allLinksEndpoint.serverLogic { _ =>
+        handleErrorsAsync(service.findAllLinkTemplates())
     }
 
     // get links for a concept
@@ -45,8 +47,8 @@ class LinkEndpoints(entityManagerFactory: EntityManagerFactory) extends Endpoint
         .description("Get all link templates applicable to a concept")
         .tag(tag)
 
-    val linksForConceptEndpointImpl: ServerEndpoint[Any, Identity] = linksForConceptEndpoint.serverLogic { name =>
-        handleErrors(service.findAllLinkTemplatesForConcept(name))
+    val linksForConceptEndpointImpl: ServerEndpoint[Any, Future] = linksForConceptEndpoint.serverLogic { name =>
+        handleErrorsAsync(service.findAllLinkTemplatesForConcept(name))
     }
 
     // get links for a concept and linkname
@@ -58,9 +60,9 @@ class LinkEndpoints(entityManagerFactory: EntityManagerFactory) extends Endpoint
         .description("Get all link templates applicable to a concept and link name")
         .tag(tag)
 
-    val linksForConceptAndLinkNameEndpointImpl: ServerEndpoint[Any, Identity] =
+    val linksForConceptAndLinkNameEndpointImpl: ServerEndpoint[Any, Future] =
         linksForConceptAndLinkNameEndpoint.serverLogic { (name, linkName) =>
-            handleErrors(service.findLinkTemplatesByNameForConcept(name, linkName))
+            handleErrorsAsync(service.findLinkTemplatesByNameForConcept(name, linkName))
         }
 
     // get link realizations for a concept
@@ -72,8 +74,8 @@ class LinkEndpoints(entityManagerFactory: EntityManagerFactory) extends Endpoint
         .description("Get all link realizations for a link name")
         .tag(tag)
 
-    val linkRealizationsEndpointImpl: ServerEndpoint[Any, Identity] = linkRealizationsEndpoint.serverLogic { linkName =>
-        handleErrors(service.findLinkRealizationsByLinkName(linkName))
+    val linkRealizationsEndpointImpl: ServerEndpoint[Any, Future] = linkRealizationsEndpoint.serverLogic { linkName =>
+        handleErrorsAsync(service.findLinkRealizationsByLinkName(linkName))
     }
 
     override def all: List[Endpoint[_, _, _, _, _]] = List(
@@ -83,7 +85,7 @@ class LinkEndpoints(entityManagerFactory: EntityManagerFactory) extends Endpoint
         allLinksEndpoint
     )
 
-    override def allImpl: List[ServerEndpoint[Any, Identity]] = List(
+    override def allImpl: List[ServerEndpoint[Any, Future]] = List(
         linkRealizationsEndpointImpl,
         linksForConceptAndLinkNameEndpointImpl,
         linksForConceptEndpointImpl,

--- a/oni/src/main/scala/org/mbari/oni/etc/sdk/IO.scala
+++ b/oni/src/main/scala/org/mbari/oni/etc/sdk/IO.scala
@@ -8,6 +8,7 @@
 package org.mbari.oni.etc.sdk
 
 import java.util.Optional
+import scala.concurrent.{ExecutionContext, Future}
 
 /**
  * Brain-dead implementation of an IO monad. This is just a simple way to represent a function that can fail. It's not a
@@ -16,6 +17,7 @@ import java.util.Optional
  * This doesn't model asyncrhonous operations, we're going to use sync operations with virual threads instead.
  */
 type IO[A, B] = A => Either[Throwable, B]
+type AsyncIO[A, B] = A => Future[Either[Throwable, B]]
 
 object IO:
     extension [A, B](io: IO[A, B])
@@ -29,3 +31,6 @@ object IO:
         def foreach(f: B => Unit): IO[A, Unit] = a =>
             for b <- io(a)
             yield f(b)
+
+        def async(using executionContext: ExecutionContext): AsyncIO[A, B] =
+            a => Future(io(a))


### PR DESCRIPTION
The major changes are to address issues related to the interaction JDBC, virtual threads, and connection pools. The current fix is not to mix JDBC and virtual threads. In this pull request, I remove all use of virtual threads.

- Remove helidon webserver/nima and use vertx.
- Change endpoints from using `Identity` to `Future`